### PR TITLE
Use DateTimeImmutable in LoggerPatternConverterDate

### DIFF
--- a/src/main/php/pattern/LoggerPatternConverterDate.php
+++ b/src/main/php/pattern/LoggerPatternConverterDate.php
@@ -77,7 +77,7 @@ class LoggerPatternConverterDate extends LoggerPatternConverter
         if ($this->useLocalDate) {
             return $this->date($this->format, $event->getTimeStamp());
         }
-        return date($this->format, (int)$event->getTimeStamp());
+        return (new \DateTimeImmutable())->format($this->format);
     }
 
     /**


### PR DESCRIPTION
As `date()` has issues with the conversion a modern approach is to use  `DateTimeImmutable()`.