### PR TITLE
Some fixes regarding nullability

### DIFF
--- a/src/main/php/pattern/LoggerPatternConverterLogger.php
+++ b/src/main/php/pattern/LoggerPatternConverterLogger.php
@@ -35,7 +35,7 @@ class LoggerPatternConverterLogger extends LoggerPatternConverter
 {
 
     /** Length to which to shorten the name. */
-    private int $length;
+    private ?int $length;
 
     /** Holds processed logger names. */
     private array $cache = array();

--- a/src/main/php/pattern/LoggerPatternConverterMessage.php
+++ b/src/main/php/pattern/LoggerPatternConverterMessage.php
@@ -31,7 +31,7 @@
 class LoggerPatternConverterMessage extends LoggerPatternConverter
 {
 
-    public function convert(LoggerLoggingEvent $event): string
+    public function convert(LoggerLoggingEvent $event): ?string
     {
         return $event->getRenderedMessage();
     }


### PR DESCRIPTION
- Bugfix: Since _LoggerLoggingEvent::getRenderedMessage()_ returns ?string, _LoggerPatternConverterMessage::convert()_ must return ?string as well. Otherwise, logging NULL (`$log->trace(NULL);`) throws an Exception.
- Bugfix: Type declaration of _$length_ was too strict - must be nullable (see _convert()_ code)